### PR TITLE
fix(auth-api): wrong cookie expiration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,66 @@
 {
   "editor.formatOnSave": true,
   "files.eol": "\n",
-  "[javascript][javascriptreact][typescript][typescriptreact][jsx][tsx][json][jsonc]": {
-    "editor.defaultFormatter": "biomejs.biome"
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "quickfix.biome": "explicit",
+      "source.organizeImports.biome": "explicit"
+    }
   },
-  "editor.codeActionsOnSave": {
-    "quickfix.biome": "explicit",
-    "source.organizeImports.biome": "explicit"
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "quickfix.biome": "explicit",
+      "source.organizeImports.biome": "explicit"
+    }
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "quickfix.biome": "explicit",
+      "source.organizeImports.biome": "explicit"
+    }
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "quickfix.biome": "explicit",
+      "source.organizeImports.biome": "explicit"
+    }
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "quickfix.biome": "explicit"
+    }
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "quickfix.biome": "explicit"
+    }
+  },
+  "[tsx]": {
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "quickfix.biome": "explicit",
+      "source.organizeImports.biome": "explicit"
+    }
+  },
+  "[jsx]": {
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "quickfix.biome": "explicit",
+      "source.organizeImports.biome": "explicit"
+    }
   }
 }

--- a/apps/api/src/handlers/auth.ts
+++ b/apps/api/src/handlers/auth.ts
@@ -51,14 +51,14 @@ const authRoutes = new Hono()
       }
 
       setCookie(c, 'access_token', data?.session.access_token, {
-        ...(data?.session.expires_at && { expires: new Date(data.session.expires_at) }),
+        maxAge: 604800, // 1 week
         httpOnly: true,
         path: '/',
         secure: true,
       });
 
       setCookie(c, 'refresh_token', data?.session.refresh_token, {
-        ...(data?.session.expires_at && { expires: new Date(data.session.expires_at) }),
+        maxAge: 31536000, // 1 year
         httpOnly: true,
         path: '/',
         secure: true,
@@ -87,7 +87,9 @@ const authRoutes = new Hono()
 
     if (data?.session) {
       setCookie(c, 'refresh_token', data.session.refresh_token, {
-        ...(data.session.expires_at && { expires: new Date(data.session.expires_at) }),
+        httpOnly: true,
+        path: '/',
+        secure: true,
       });
     }
 


### PR DESCRIPTION
Since we use free tier of supabase for now, User sessions is infinite so expires date of the cookie was set to 1970 and then it was deleted at every re compilation.

access_token -> 1 week max (will be less for prod)
refresh_token -> 1 year max