### PR TITLE
feat(client): add documents page

### DIFF
--- a/apps/client/app/(auth)/(members)/members/documents/page.tsx
+++ b/apps/client/app/(auth)/(members)/members/documents/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@repo/ui/components/ui/table';
+import { Eye } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { type Files, getAllFiles } from './utils';
+
+export default function Documents() {
+  const [files, setFiles] = useState<{ data: Files[]; count: number } | null>(null);
+
+  useEffect(() => {
+    const getFIles = async () => {
+      const files = await getAllFiles();
+      setFiles(files);
+    };
+    getFIles();
+  }, []);
+
+  async function viewFile(id: number) {
+    const API_URL = process.env.NEXT_PUBLIC_API_URL;
+    const token = localStorage.getItem('access_token');
+    const response = await fetch(`${API_URL}/edm/download/${id}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!response.ok) {
+      throw new Error('Failed to download file');
+    }
+
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+    window.open(url, '_blank');
+  }
+
+  function fileTypes(input: string) {
+    switch (input) {
+      case 'application/pdf' || 'application/x-pdf':
+        return 'PDF';
+      case 'application/msword' || 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+        return 'Word';
+      case input.includes('image') && input:
+        return 'Image';
+      default:
+        return 'Other';
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <header className="bg-gray-100 dark:bg-gray-800 px-6 py-4 flex items-center justify-between">
+        <h1 className="text-xl font-bold">Documents d'Athlonix</h1>
+      </header>
+      <div className="flex-1 overflow-auto p-6">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Nom</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Uploaded</TableHead>
+              <TableHead>Updated</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {files?.data.map((file) => (
+              <TableRow key={file.id}>
+                <TableCell>{file.name}</TableCell>
+                <TableCell>{file.description || 'Aucune description'}</TableCell>
+                <TableCell>{fileTypes(file.type)}</TableCell>
+                <TableCell>{`${new Date(file.created_at).toLocaleDateString()} ${new Date(
+                  file.created_at,
+                ).toLocaleTimeString()}`}</TableCell>
+                <TableCell>{`${new Date(file.updated_at).toLocaleDateString()} ${new Date(
+                  file.updated_at,
+                ).toLocaleTimeString()}`}</TableCell>
+                <TableCell className="flex gap-2">
+                  <Eye className="cursor-pointer" onClick={() => viewFile(file.id)} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/app/(auth)/(members)/members/documents/utils.ts
+++ b/apps/client/app/(auth)/(members)/members/documents/utils.ts
@@ -1,0 +1,83 @@
+'use server';
+import { cookies } from 'next/headers';
+
+export type Files = {
+  id: number;
+  name: string;
+  description: string;
+  owner: number;
+  isAdmin: boolean;
+  updated_at: string;
+  created_at: string;
+  type: string;
+};
+
+export async function saveFile(form: FormData): Promise<void> {
+  const API_URL = process.env.ATHLONIX_API_URL;
+  const token = cookies().get('access_token')?.value;
+  if (form.get('isAdmin') === 'on') {
+    form.set('isAdmin', 'true');
+  } else {
+    form.set('isAdmin', 'false');
+  }
+  const response = await fetch(`${API_URL}/edm/upload`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    body: form,
+  });
+  if (!response.ok) {
+    throw new Error('Failed to save file');
+  }
+}
+
+export async function getAllFiles(): Promise<{ data: Files[]; count: number }> {
+  const API_URL = process.env.ATHLONIX_API_URL;
+  const token = cookies().get('access_token')?.value;
+  const response = await fetch(`${API_URL}/edm/listFiles?all=true`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!response.ok) {
+    throw new Error('Failed to fetch files');
+  }
+  return await response.json();
+}
+
+export async function deleteFile(id: number, name: string): Promise<void> {
+  const API_URL = process.env.ATHLONIX_API_URL;
+  const token = cookies().get('access_token')?.value;
+  const response = await fetch(`${API_URL}/edm/delete`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ id, name }),
+  });
+  if (!response.ok) {
+    throw new Error('Failed to delete file');
+  }
+}
+
+export async function updateFile(form: FormData, id: number): Promise<void> {
+  const API_URL = process.env.ATHLONIX_API_URL;
+  const token = cookies().get('access_token')?.value;
+  if (form.get('isAdmin') === 'on') {
+    form.set('isAdmin', 'true');
+  } else {
+    form.set('isAdmin', 'false');
+  }
+  const response = await fetch(`${API_URL}/edm/update/${id}`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    body: form,
+  });
+  if (!response.ok) {
+    throw new Error('Failed to update file');
+  }
+}

--- a/apps/client/app/(withNavbar)/activities/details/page.tsx
+++ b/apps/client/app/(withNavbar)/activities/details/page.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function page() {
   return <div>TODO</div>;
 }


### PR DESCRIPTION
## Summary 📝
<!--- Describe your changes, include tickets if applicable -->
Document page like Admin but readonly

## Which part of the repository is impacted ?

- [ ] API
- [x] Client
- [ ] Admin
- [ ] Documentation
- [ ] CI/CD
- [ ] Other

## Test plan 🧪
<!--- Please describe the tests that you ran to verify your changes or which need to be done -->

## Screenshots (if appropriate): 📸
Same as admin
