### PR TITLE
fix: comments delete cascade

### DIFF
--- a/apps/api/test/blog.test.ts
+++ b/apps/api/test/blog.test.ts
@@ -42,90 +42,275 @@ describe('Blog tests', () => {
     jwt = loginUser.token;
   });
 
-  test('Create post', async () => {
-    const res = await app.request('/blog/posts', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${jwt}`,
-      },
-      body: JSON.stringify({
+  describe('Post operations', () => {
+    test('Create post', async () => {
+      const res = await app.request('/blog/posts', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${jwt}`,
+        },
+        body: JSON.stringify({
+          title: 'Post test',
+          content: 'Post test content',
+          cover_image: 'https://example.com/image.jpg',
+          description: 'Post test description',
+        }),
+      });
+      expect(res.status).toBe(201);
+      const post: { id: number; title: string; content: string } = await res.json();
+      id_post = post.id;
+      expect(post.title).toBe('Post test');
+      expect(post.content).toBe('Post test content');
+    });
+
+    test('Get post', async () => {
+      const res = await app.request(`/blog/posts/${id_post}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      expect(res.status).toBe(200);
+      const post: { title: string; content: string; cover_image: string; description: string } = await res.json();
+      expect(post).toMatchObject({
         title: 'Post test',
         content: 'Post test content',
         cover_image: 'https://example.com/image.jpg',
         description: 'Post test description',
-      }),
+      });
     });
-    expect(res.status).toBe(201);
-    const post: { id: number } = await res.json();
-    id_post = post.id;
+
+    test('Update post', async () => {
+      const res = await app.request(`/blog/posts/${id_post}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${jwt}`,
+        },
+        body: JSON.stringify({
+          title: 'Post test updated',
+          content: 'Post test content updated',
+        }),
+      });
+      expect(res.status).toBe(200);
+      const updatedPost: { title: string; content: string } = await res.json();
+      expect(updatedPost.title).toBe('Post test updated');
+      expect(updatedPost.content).toBe('Post test content updated');
+    });
+
+    test('Get all posts', async () => {
+      const res = await app.request('/blog/posts', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      expect(res.status).toBe(200);
+      const postsResponse: { data: { title: string; content: string }[]; count: number } = await res.json();
+      expect(Array.isArray(postsResponse.data)).toBeTruthy();
+      expect(typeof postsResponse.count).toBe('number');
+      expect(postsResponse.data.length).toBeGreaterThan(0);
+    });
+
+    test('Attempt to create post without authentication', async () => {
+      const res = await app.request('/blog/posts', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title: 'Unauthorized post',
+          content: 'This should not be created',
+        }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    test('Attempt to update non-existent post', async () => {
+      const res = await app.request('/blog/posts/99999', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${jwt}`,
+        },
+        body: JSON.stringify({
+          title: 'Non-existent post',
+        }),
+      });
+      expect(res.status).toBe(404);
+    });
   });
 
-  test('Get post', async () => {
-    const res = await app.request(`/blog/posts/${id_post}`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+  describe('Comment operations', () => {
+    test('Comment on the post', async () => {
+      const res = await app.request(`/blog/posts/${id_post}/comments`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${jwt}`,
+        },
+        body: JSON.stringify({
+          content: 'Comment test',
+        }),
+      });
+      expect(res.status).toBe(201);
+      const comment: { id: number; content: string } = await res.json();
+      id_comment = comment.id;
+      expect(comment.content).toBe('Comment test');
     });
-    expect(res.status).toBe(200);
-    const post: { title: string } = await res.json();
-    expect(post).toMatchObject({ title: 'Post test' });
+
+    test('Get comments', async () => {
+      const res = await app.request(`/blog/posts/${id_post}/comments`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      expect(res.status).toBe(200);
+      const comments: { data: Comment[]; count: number } = await res.json();
+      expect(Array.isArray(comments.data)).toBeTruthy();
+      expect(typeof comments.count).toBe('number');
+      expect(comments.data.length).toBeGreaterThan(0);
+    });
+
+    test('Update comment', async () => {
+      const res = await app.request(`/blog/posts/${id_post}/comments/${id_comment}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${jwt}`,
+        },
+        body: JSON.stringify({
+          content: 'Updated comment',
+        }),
+      });
+      expect(res.status).toBe(200);
+      const updatedComment: { content: string } = await res.json();
+      expect(updatedComment.content).toBe('Updated comment');
+    });
+
+    test('Attempt to comment without authentication', async () => {
+      const res = await app.request(`/blog/posts/${id_post}/comments`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          content: 'Unauthorized comment',
+        }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    test('Delete comment', async () => {
+      const res = await app.request(`/blog/posts/${id_post}/comments/${id_comment}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${jwt}`,
+        },
+      });
+      expect(res.status).toBe(200);
+    });
+
+    test('Attempt to delete non-existent comment', async () => {
+      const res = await app.request(`/blog/posts/${id_post}/comments/99999`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${jwt}`,
+        },
+      });
+      expect(res.status).toBe(404);
+    });
   });
 
-  test('Update post', async () => {
-    const res = await app.request(`/blog/posts/${id_post}`, {
+  describe('Post responses', () => {
+    let id_response: number;
+
+    test('Create response to a comment', async () => {
+      const commentRes = await app.request(`/blog/posts/${id_post}/comments`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${jwt}`,
+        },
+        body: JSON.stringify({
+          content: 'Parent comment',
+        }),
+      });
+      expect(commentRes.status).toBe(201);
+      const comment: { id: number; content: string } = await commentRes.json();
+
+      const res = await app.request(`/blog/posts/${id_post}/comments/${comment.id}/responses`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${jwt}`,
+        },
+        body: JSON.stringify({
+          content: 'Response to comment',
+        }),
+      });
+      expect(res.status).toBe(201);
+      const response: { id: number; content: string } = await res.json();
+      id_response = response.id;
+      expect(response.content).toBe('Response to comment');
+    });
+
+    test('Get responses for a comment', async () => {
+      const res = await app.request(`/blog/posts/${id_post}/comments`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      expect(res.status).toBe(200);
+      const comments: { data: { id: number; content: string }[] } = await res.json();
+      expect(comments.data.some((comment) => comment.id === id_response)).toBeTruthy();
+    });
+
+    test('Update response', async () => {
+      const res = await app.request(`/blog/posts/${id_post}/comments/${id_response}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${jwt}`,
+        },
+        body: JSON.stringify({
+          content: 'Updated response',
+        }),
+      });
+      expect(res.status).toBe(200);
+      const updatedResponse: { content: string } = await res.json();
+      expect(updatedResponse.content).toBe('Updated response');
+    });
+
+    test('Delete response', async () => {
+      const res = await app.request(`/blog/posts/${id_post}/comments/${id_response}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${jwt}`,
+        },
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  test('Soft delete post', async () => {
+    const res = await app.request(`/blog/posts/${id_post}/soft`, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${jwt}`,
       },
-      body: JSON.stringify({
-        title: 'Post test updated',
-        content: 'Post test content updated',
-      }),
     });
     expect(res.status).toBe(200);
   });
 
-  test('Comment the post', async () => {
-    const res = await app.request(`/blog/posts/${id_post}/comments`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${jwt}`,
-      },
-      body: JSON.stringify({
-        content: 'Comment test',
-      }),
-    });
-    expect(res.status).toBe(201);
-    const comment: { id: number } = await res.json();
-    id_comment = comment.id;
-  });
-
-  test('Get comments', async () => {
-    const res = await app.request(`/blog/posts/${id_post}/comments`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-    expect(res.status).toBe(200);
-  });
-
-  test('Delete comment', async () => {
-    const res = await app.request(`/blog/posts/${id_post}/comments/${id_comment}`, {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${jwt}`,
-      },
-    });
-    expect(res.status).toBe(200);
-  });
-
-  test('Delete post', async () => {
+  test('Full delete post', async () => {
     const res = await app.request(`/blog/posts/${id_post}`, {
       method: 'DELETE',
       headers: {

--- a/supabase/migrations/20240508143034_blog.sql
+++ b/supabase/migrations/20240508143034_blog.sql
@@ -130,4 +130,26 @@ grant truncate on table "public"."POSTS_VIEWS" to "service_role";
 
 grant update on table "public"."POSTS_VIEWS" to "service_role";
 
+alter table "public"."COMMENTS" drop constraint "public_COMMENTS_id_post_fkey";
 
+alter table "public"."COMMENTS" add constraint "public_COMMENTS_id_post_fkey" FOREIGN KEY (id_post) REFERENCES "POSTS"(id) ON DELETE SET NULL not valid;
+
+alter table "public"."COMMENTS" validate constraint "public_COMMENTS_id_post_fkey";
+
+alter table "public"."COMMENTS" drop constraint "comments_id_comment_fkey";
+
+alter table "public"."COMMENTS" drop constraint "public_COMMENTS_id_activity_fkey";
+
+alter table "public"."COMMENTS" drop constraint "public_COMMENTS_id_user_fkey";
+
+alter table "public"."COMMENTS" add constraint "public_COMMENTS_id_response_fkey" FOREIGN KEY (id_response) REFERENCES "COMMENTS"(id) ON DELETE CASCADE not valid;
+
+alter table "public"."COMMENTS" validate constraint "public_COMMENTS_id_response_fkey";
+
+alter table "public"."COMMENTS" add constraint "public_COMMENTS_id_activity_fkey" FOREIGN KEY (id_activity) REFERENCES "ACTIVITIES"(id) ON DELETE SET NULL not valid;
+
+alter table "public"."COMMENTS" validate constraint "public_COMMENTS_id_activity_fkey";
+
+alter table "public"."COMMENTS" add constraint "public_COMMENTS_id_user_fkey" FOREIGN KEY (id_user) REFERENCES "USERS"(id) ON DELETE CASCADE not valid;
+
+alter table "public"."COMMENTS" validate constraint "public_COMMENTS_id_user_fkey";


### PR DESCRIPTION
## Summary 📝
<!--- Describe your changes, include tickets if applicable -->
Deletion rules were missing in the `comments` table when the post or user is deleted.
Added more test case.

## Which part of the repository is impacted ?

- [X] API
- [ ] Client
- [ ] Admin
- [ ] Documentation
- [ ] CI/CD
- [ ] Other
